### PR TITLE
Fixed relationship time parsing

### DIFF
--- a/lib/crunchbase/relationship.rb
+++ b/lib/crunchbase/relationship.rb
@@ -12,9 +12,9 @@ module Crunchbase
       @announced_on = hash["announced_on"] && DateTime.parse(hash["announced_on"])
       @name         = hash["name"]
       @path         = hash["path"]
-      @permalink    = hash["path"] && hash["path"].split('/').last
-      @created_at   = hash['created_at'] && Time.at(hash['created_at']).utc
-      @updated_at   = hash['updated_at'] && Time.at(hash['updated_at']).utc
+      @permalink    = hash["path"] && hash["path"].split("/").last
+      @created_at   = hash["created_at"] && (hash["created_at"].kind_of?(String) ? DateTime.parse(hash["created_at"]) : Time.at(hash["created_at"]).utc)
+      @updated_at   = hash["updated_at"] && (hash["updated_at"].kind_of?(String) ? DateTime.parse(hash["updated_at"]) : Time.at(hash["updated_at"]).utc)
     end
     
   end

--- a/spec/crunchbase/organization_spec.rb
+++ b/spec/crunchbase/organization_spec.rb
@@ -26,8 +26,14 @@ module Crunchbase
     its(:new_items_total_items) { should eq(3118) }
     its(:board_members_and_advisors_total_items) { should eq(12) }
 
-    describe '.search' do
+    describe 'search by domain' do
       subject { Organization.search({ domain_name: "facebook.com", organization_types: 'company' }) }
+
+      it_has_behavior 'pagination'
+    end
+
+    describe 'search by query' do
+      subject { Organization.search({ query: "youtube" }) }
 
       it_has_behavior 'pagination'
     end


### PR DESCRIPTION
Lately crunchbase started to return cratead and updated at times not strictly as timestamps but also as date time strings such as `2015-06-30T22:14:29-07:00`. This PR fixes this issue.

Example of such a bad format is searching organizations by query "you":

```
https://api.crunchbase.com/v/2/organizations?query=you&page=1&order=created_at+asc&user_key={your_key}
```

![screen shot 2015-07-01 at 15 43 45](https://cloud.githubusercontent.com/assets/153201/8455899/3407493a-2008-11e5-863b-d80e9b664049.png)
